### PR TITLE
Modifying date time formatters to use local time.

### DIFF
--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameDetailDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameDetailDisplayModel.kt
@@ -1,12 +1,14 @@
 package com.adammcneilly.pwhl.mobile.shared.displaymodels
 
 import com.adammcneilly.pwhl.mobile.shared.models.GameDetail
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
-import kotlinx.datetime.format.DateTimeComponents
 import kotlinx.datetime.format.DayOfWeekNames
 import kotlinx.datetime.format.MonthNames
 import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
 
 data class GameDetailDisplayModel(
     val id: String,
@@ -33,7 +35,7 @@ data class GameDetailDisplayModel(
 }
 
 private fun GameDetail.dateString(): String {
-    val gameDateFormat = DateTimeComponents.Format {
+    val gameDateFormat = LocalDateTime.Format {
         dayOfWeek(DayOfWeekNames.ENGLISH_ABBREVIATED)
         char(',')
         char(' ')
@@ -42,5 +44,7 @@ private fun GameDetail.dateString(): String {
         dayOfMonth(padding = Padding.NONE)
     }
 
-    return this.time.format(gameDateFormat)
+    val localDate = this.time.toLocalDateTime(TimeZone.currentSystemDefault())
+
+    return localDate.format(gameDateFormat)
 }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameDetailDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameDetailDisplayModel.kt
@@ -44,7 +44,7 @@ private fun GameDetail.dateString(): String {
         dayOfMonth(padding = Padding.NONE)
     }
 
-    val localDate = this.time.toLocalDateTime(TimeZone.currentSystemDefault())
+    val localDateTime = this.time.toLocalDateTime(TimeZone.currentSystemDefault())
 
-    return localDate.format(gameDateFormat)
+    return localDateTime.format(gameDateFormat)
 }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameSummaryDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameSummaryDisplayModel.kt
@@ -1,12 +1,14 @@
 package com.adammcneilly.pwhl.mobile.shared.displaymodels
 
 import com.adammcneilly.pwhl.mobile.shared.models.GameSummary
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
-import kotlinx.datetime.format.DateTimeComponents
 import kotlinx.datetime.format.DayOfWeekNames
 import kotlinx.datetime.format.MonthNames
 import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
 
 data class GameSummaryDisplayModel(
     val id: String,
@@ -29,7 +31,7 @@ data class GameSummaryDisplayModel(
 }
 
 private fun GameSummary.dateString(): String {
-    val gameDateFormat = DateTimeComponents.Format {
+    val gameDateFormat = LocalDateTime.Format {
         dayOfWeek(DayOfWeekNames.ENGLISH_ABBREVIATED)
         char(',')
         char(' ')
@@ -38,5 +40,7 @@ private fun GameSummary.dateString(): String {
         dayOfMonth(padding = Padding.NONE)
     }
 
-    return this.time.format(gameDateFormat)
+    val localTime = this.time.toLocalDateTime(TimeZone.currentSystemDefault())
+
+    return localTime.format(gameDateFormat)
 }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameSummaryDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameSummaryDisplayModel.kt
@@ -40,7 +40,7 @@ private fun GameSummary.dateString(): String {
         dayOfMonth(padding = Padding.NONE)
     }
 
-    val localTime = this.time.toLocalDateTime(TimeZone.currentSystemDefault())
+    val localDateTime = this.time.toLocalDateTime(TimeZone.currentSystemDefault())
 
-    return localTime.format(gameDateFormat)
+    return localDateTime.format(gameDateFormat)
 }


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

This explains why sometimes the date wasn't what I expected it to be. When formatting visually, we should have considered users time zone. 
