### PR TITLE
Tweaking immersive design configuration

### DIFF
--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloseFullscreen
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -26,6 +27,7 @@ import androidx.xr.compose.subspace.SpatialColumn
 import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.SpatialRow
 import androidx.xr.compose.subspace.SpatialRowScope
+import androidx.xr.compose.subspace.layout.SpatialRoundedCornerShape
 import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.fillMaxWidth
 import androidx.xr.compose.subspace.layout.height
@@ -141,6 +143,7 @@ private fun SpatialRowScope.MVPPanel(
     game: GameDetailDisplayModel,
 ) {
     SpatialPanel(
+        shape = SpatialRoundedCornerShape(ZeroCornerSize),
         modifier = SubspaceModifier
             .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
             .weight(1F),
@@ -151,6 +154,7 @@ private fun SpatialRowScope.MVPPanel(
             game.mostValuablePlayers.forEach { mvp ->
                 MVPCard(
                     mvp = mvp,
+                    shape = MaterialTheme.shapes.extraLarge,
                     modifier = Modifier
                         .fillMaxWidth(),
                 )

--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
@@ -1,5 +1,8 @@
 package com.adammcneilly.pwhl.mobile.shared.gamedetail.xr
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -20,6 +23,7 @@ import androidx.xr.compose.spatial.Orbiter
 import androidx.xr.compose.spatial.OrbiterEdge
 import androidx.xr.compose.spatial.Subspace
 import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.SpatialRow
 import androidx.xr.compose.subspace.SpatialRowScope
 import androidx.xr.compose.subspace.layout.SubspaceModifier
@@ -30,7 +34,7 @@ import androidx.xr.compose.subspace.layout.width
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.gamedetail.GameDetailState
 import com.adammcneilly.pwhl.mobile.shared.gamedetail.GameDetailStatsTab
-import com.adammcneilly.pwhl.mobile.shared.gamedetail.GameDetailSummaryTab
+import com.adammcneilly.pwhl.mobile.shared.gamedetail.mvp.MVPCard
 import com.adammcneilly.pwhl.mobile.shared.gamedetail.playbyplay.PlayByPlayList
 import com.adammcneilly.pwhl.mobile.shared.ui.components.SpatialSurface
 import com.adammcneilly.pwhl.mobile.shared.xr.XRSession
@@ -71,7 +75,7 @@ private fun GameDetailPanels(
         modifier = SubspaceModifier
             .width(IMMERSIVE_GAME_DETAIL_WIDTH),
     ) {
-        SummaryPanel(game)
+        MVPPanel(game)
 
         StatsPanel()
 
@@ -133,17 +137,25 @@ private fun EnterHomeSpaceButton(
 }
 
 @Composable
-private fun SpatialRowScope.SummaryPanel(
+private fun SpatialRowScope.MVPPanel(
     game: GameDetailDisplayModel,
 ) {
-    SpatialSurface(
+    SpatialPanel(
         modifier = SubspaceModifier
             .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
             .weight(1F),
     ) {
-        GameDetailSummaryTab(
-            game = game,
-        )
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            game.mostValuablePlayers.forEach { mvp ->
+                MVPCard(
+                    mvp = mvp,
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                )
+            }
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
@@ -26,7 +26,6 @@ import androidx.xr.compose.spatial.Subspace
 import androidx.xr.compose.subspace.SpatialColumn
 import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.SpatialRow
-import androidx.xr.compose.subspace.SpatialRowScope
 import androidx.xr.compose.subspace.layout.SpatialRoundedCornerShape
 import androidx.xr.compose.subspace.layout.SubspaceModifier
 import androidx.xr.compose.subspace.layout.fillMaxWidth
@@ -41,8 +40,8 @@ import com.adammcneilly.pwhl.mobile.shared.gamedetail.playbyplay.PlayByPlayList
 import com.adammcneilly.pwhl.mobile.shared.ui.components.SpatialSurface
 import com.adammcneilly.pwhl.mobile.shared.xr.XRSession
 
-private val IMMERSIVE_GAME_DETAIL_WIDTH = 1200.dp
-private val IMMERSIVE_DETAIL_PANEL_HEIGHT = 600.dp
+private val IMMERSIVE_GAME_DETAIL_WIDTH = 1400.dp
+private val IMMERSIVE_DETAIL_PANEL_HEIGHT = 1000.dp
 
 @Composable
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -57,31 +56,43 @@ actual fun ImmersiveGameDetailContent(
     }
 
     Subspace {
-        SpatialColumn(
+        SpatialRow(
             modifier = SubspaceModifier
                 .width(IMMERSIVE_GAME_DETAIL_WIDTH),
         ) {
-            Header(xrSession, state.game)
+            StatsPanel(
+                modifier = SubspaceModifier
+                    .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
+                    .weight(1F),
+            )
 
-            GameDetailPanels(state.game, state)
+            SpatialColumn(
+                modifier = SubspaceModifier
+                    .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
+                    .weight(1F)
+                    .padding(
+                        horizontal = 16.dp,
+                    ),
+            ) {
+                Header(
+                    xrSession = xrSession,
+                    game = state.game,
+                )
+
+                MVPPanel(
+                    game = state.game,
+                    modifier = SubspaceModifier
+                        .weight(1F),
+                )
+            }
+
+            PlayByPlayPanel(
+                state = state,
+                modifier = SubspaceModifier
+                    .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
+                    .weight(1F),
+            )
         }
-    }
-}
-
-@Composable
-private fun GameDetailPanels(
-    game: GameDetailDisplayModel,
-    state: GameDetailState,
-) {
-    SpatialRow(
-        modifier = SubspaceModifier
-            .width(IMMERSIVE_GAME_DETAIL_WIDTH),
-    ) {
-        MVPPanel(game)
-
-        StatsPanel()
-
-        PlayByPlayPanel(state)
     }
 }
 
@@ -89,15 +100,16 @@ private fun GameDetailPanels(
 private fun Header(
     xrSession: XRSession,
     game: GameDetailDisplayModel,
+    modifier: SubspaceModifier = SubspaceModifier,
 ) {
     SpatialSurface(
-        modifier = SubspaceModifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(bottom = 16.dp),
     ) {
         EnterHomeSpaceButton(xrSession)
 
-        SpatialGameDetailHeader(
+        ImmersiveGameDetailHeader(
             game = game,
         )
     }
@@ -139,14 +151,13 @@ private fun EnterHomeSpaceButton(
 }
 
 @Composable
-private fun SpatialRowScope.MVPPanel(
+private fun MVPPanel(
     game: GameDetailDisplayModel,
+    modifier: SubspaceModifier = SubspaceModifier,
 ) {
     SpatialPanel(
         shape = SpatialRoundedCornerShape(ZeroCornerSize),
-        modifier = SubspaceModifier
-            .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
-            .weight(1F),
+        modifier = modifier,
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -164,25 +175,23 @@ private fun SpatialRowScope.MVPPanel(
 }
 
 @Composable
-private fun SpatialRowScope.StatsPanel() {
+private fun StatsPanel(
+    modifier: SubspaceModifier = SubspaceModifier,
+) {
     SpatialSurface(
-        modifier = SubspaceModifier
-            .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
-            .weight(1F)
-            .padding(horizontal = 16.dp),
+        modifier = modifier,
     ) {
         GameDetailStatsTab()
     }
 }
 
 @Composable
-private fun SpatialRowScope.PlayByPlayPanel(
+private fun PlayByPlayPanel(
     state: GameDetailState,
+    modifier: SubspaceModifier = SubspaceModifier,
 ) {
     SpatialSurface(
-        modifier = SubspaceModifier
-            .height(IMMERSIVE_DETAIL_PANEL_HEIGHT)
-            .weight(1F),
+        modifier = modifier,
     ) {
         PlayByPlayList(
             events = state.playByPlayEvents,

--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/SpatialGameDetailHeader.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/SpatialGameDetailHeader.kt
@@ -23,33 +23,55 @@ import com.adammcneilly.pwhl.mobile.shared.ui.theme.PWHLTheme
 private const val GAME_STATUS_WIDTH_RATIO = 0.50F
 
 @Composable
-fun SpatialGameDetailHeader(
+fun ImmersiveGameDetailHeader(
     game: GameDetailDisplayModel,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(PWHLTheme.dimensions.componentVerticalPadding),
         modifier = modifier
-            .padding(32.dp),
+            .padding(PWHLTheme.dimensions.componentPadding),
     ) {
-        TeamNameLogo(
-            team = game.homeTeam.team,
-        )
-
-        TeamScore(
-            teamGameResult = game.homeTeam,
-        )
+        TeamScores(game)
 
         GameSummary(game)
+    }
+}
 
-        TeamScore(
-            teamGameResult = game.awayTeam,
-        )
+@Composable
+private fun TeamScores(
+    game: GameDetailDisplayModel,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TeamNameLogo(
+                team = game.homeTeam.team,
+            )
 
-        TeamNameLogo(
-            team = game.awayTeam.team,
-        )
+            TeamScore(
+                teamGameResult = game.homeTeam,
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TeamScore(
+                teamGameResult = game.awayTeam,
+            )
+
+            TeamNameLogo(
+                team = game.awayTeam.team,
+            )
+        }
     }
 }
 
@@ -59,17 +81,15 @@ private fun GameSummary(
     game: GameDetailDisplayModel,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier,
     ) {
         Text(
             text = game.status,
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth(GAME_STATUS_WIDTH_RATIO),
         )
 
         Text(

--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/SpatialGameDetailHeader.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/SpatialGameDetailHeader.kt
@@ -20,8 +20,6 @@ import com.adammcneilly.pwhl.mobile.shared.displaymodels.TeamGameDetailResultDis
 import com.adammcneilly.pwhl.mobile.shared.ui.components.ImageWrapper
 import com.adammcneilly.pwhl.mobile.shared.ui.theme.PWHLTheme
 
-private const val GAME_STATUS_WIDTH_RATIO = 0.50F
-
 @Composable
 fun ImmersiveGameDetailHeader(
     game: GameDetailDisplayModel,

--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/SpatialGameDetailHeader.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/SpatialGameDetailHeader.kt
@@ -18,6 +18,7 @@ import com.adammcneilly.pwhl.mobile.shared.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.TeamDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.TeamGameDetailResultDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.ui.components.ImageWrapper
+import com.adammcneilly.pwhl.mobile.shared.ui.theme.PWHLTheme
 
 private const val GAME_STATUS_WIDTH_RATIO = 0.50F
 
@@ -101,7 +102,7 @@ private fun TeamNameLogo(
             image = team.image,
             contentDescription = team.name,
             modifier = Modifier
-                .size(48.dp),
+                .size(PWHLTheme.dimensions.imageSizeDefault),
         )
 
         Text(

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/PWHLApp.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/PWHLApp.kt
@@ -19,9 +19,20 @@ import org.koin.compose.KoinApplication
 
 @Composable
 fun PWHLApp() {
+    val xrSession = currentXRSession()
+
+    // This is a temporary work around to provide a special dimension to be used in an immersive situation.
+    // Ideally we don't set dimensions based on capabilities, but window size, and there will hopefully
+    // be updates to Android XR in the future that make that decision easier.
+    val dimensions = if (xrSession?.isSpatialUiEnabled == true) {
+        Dimensions.immersive
+    } else {
+        Dimensions.get(currentWindowSizeClass())
+    }
+
     CompositionLocalProvider(
-        LocalXRSession provides currentXRSession(),
-        LocalDimensions provides Dimensions.get(currentWindowSizeClass()),
+        LocalXRSession provides xrSession,
+        LocalDimensions provides dimensions,
     ) {
         KoinApplication(
             application = {

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/GameDetailHeader.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/GameDetailHeader.kt
@@ -20,6 +20,7 @@ import com.adammcneilly.pwhl.mobile.shared.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.TeamDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.TeamGameDetailResultDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.ui.components.ImageWrapper
+import com.adammcneilly.pwhl.mobile.shared.ui.theme.PWHLTheme
 
 private const val GAME_STATUS_WIDTH_RATIO = 0.50F
 
@@ -134,7 +135,7 @@ private fun TeamNameLogo(
                 image = team.image,
                 contentDescription = team.name,
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(PWHLTheme.dimensions.imageSizeDefault)
                     .sharedElement(
                         state = rememberSharedContentState(key = "${team.name}_${gameId}_image"),
                         animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current,

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
@@ -46,6 +46,7 @@ fun MVPCard(
         ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(PWHLTheme.dimensions.componentHorizontalPadding),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 PlayerImage(mvp)
 
@@ -110,9 +111,20 @@ private fun PlayerInfo(
 private fun PlayerName(
     mvp: MostValuablePlayerDisplayModel,
 ) {
+    val imageSize = PWHLTheme.dimensions.imageSizeDefault
+
+    val fontSize = with(LocalDensity.current) {
+        imageSize.div(3).toSp()
+    }
+
+    val textStyle = MaterialTheme.typography.titleSmall.copy(
+        fontSize = fontSize,
+        lineHeight = fontSize.times(1.25),
+    )
+
     Text(
         text = mvp.player.fullName,
-        style = MaterialTheme.typography.titleSmall,
+        style = textStyle,
     )
 }
 
@@ -124,19 +136,31 @@ private fun PlayerSubtitle(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        with(LocalDensity.current) {
-            ImageWrapper(
-                image = mvp.team.image,
-                contentDescription = mvp.team.name,
-                modifier = Modifier
-                    .size(LocalTextStyle.current.fontSize.toDp()),
-            )
+        val imageSize = PWHLTheme.dimensions.imageSizeDefault
+
+        val fontSizeDp = imageSize.div(4)
+
+        val fontSizeSp = with(LocalDensity.current) {
+            fontSizeDp.toSp()
         }
+
+        val textStyle = LocalTextStyle.current.copy(
+            fontSize = fontSizeSp,
+            lineHeight = fontSizeSp.times(1.25),
+        )
+
+        ImageWrapper(
+            image = mvp.team.image,
+            contentDescription = mvp.team.name,
+            modifier = Modifier
+                .size(fontSizeDp),
+        )
 
         val subtitle = "#${mvp.player.jerseyNumber} • ${mvp.player.position}"
 
         Text(
             text = subtitle,
+            style = textStyle,
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MagicNumber")
+
 package com.adammcneilly.pwhl.mobile.shared.gamedetail.mvp
 
 import androidx.compose.foundation.layout.Arrangement

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
@@ -25,24 +26,26 @@ import com.adammcneilly.pwhl.mobile.shared.displaymodels.ImageDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.MostValuablePlayerDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.StatDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.ui.components.ImageWrapper
+import com.adammcneilly.pwhl.mobile.shared.ui.theme.PWHLTheme
 
 @Composable
 fun MVPCard(
     mvp: MostValuablePlayerDisplayModel,
     modifier: Modifier = Modifier,
+    shape: Shape = MaterialTheme.shapes.large,
 ) {
     Card(
-        shape = MaterialTheme.shapes.large,
+        shape = shape,
         modifier = modifier
             .width(IntrinsicSize.Max),
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(PWHLTheme.dimensions.componentVerticalPadding),
             modifier = Modifier
-                .padding(8.dp),
+                .padding(PWHLTheme.dimensions.componentPadding),
         ) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalArrangement = Arrangement.spacedBy(PWHLTheme.dimensions.componentHorizontalPadding),
             ) {
                 PlayerImage(mvp)
 
@@ -147,7 +150,7 @@ private fun PlayerImage(
         contentDescription = mvp.player.fullName,
         contentScale = ContentScale.Crop,
         modifier = Modifier
-            .size(48.dp)
+            .size(PWHLTheme.dimensions.imageSizeDefault)
             .clip(CircleShape),
     )
 }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/theme/Dimensions.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/theme/Dimensions.kt
@@ -12,6 +12,7 @@ val LocalDimensions = staticCompositionLocalOf {
     Dimensions(
         componentHorizontalPadding = 0.dp,
         componentVerticalPadding = 0.dp,
+        imageSizeDefault = 0.dp,
     )
 }
 
@@ -19,6 +20,7 @@ val LocalDimensions = staticCompositionLocalOf {
 data class Dimensions(
     val componentHorizontalPadding: Dp,
     val componentVerticalPadding: Dp,
+    val imageSizeDefault: Dp,
 ) {
     val componentPadding: PaddingValues
         get() = PaddingValues(
@@ -30,16 +32,25 @@ data class Dimensions(
         private val compact = Dimensions(
             componentHorizontalPadding = 8.dp,
             componentVerticalPadding = 8.dp,
+            imageSizeDefault = 48.dp,
         )
 
         private val medium = Dimensions(
             componentHorizontalPadding = 8.dp,
             componentVerticalPadding = 8.dp,
+            imageSizeDefault = 48.dp,
         )
 
         private val expanded = Dimensions(
             componentHorizontalPadding = 16.dp,
             componentVerticalPadding = 16.dp,
+            imageSizeDefault = 72.dp,
+        )
+
+        val immersive = Dimensions(
+            componentHorizontalPadding = 16.dp,
+            componentVerticalPadding = 16.dp,
+            imageSizeDefault = 96.dp,
         )
 
         fun get(

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/theme/Shape.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/theme/Shape.kt
@@ -8,4 +8,5 @@ val Shapes = Shapes(
     small = RoundedCornerShape(4.dp),
     medium = RoundedCornerShape(4.dp),
     large = RoundedCornerShape(16.dp),
+    extraLarge = RoundedCornerShape(32.dp),
 )


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Putting summary and MVPs in middle with stronger detailed panels on the sides makes it feel a little more "immersive". 

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Full Space</summary>

![Screenshot_1734986026](https://github.com/user-attachments/assets/56234df3-6043-49ec-b6d6-a51da1e40e27)


</details>