### PR TITLE
Using full name or shortcode on MVP card based on window size class. 

### DIFF
--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
@@ -160,7 +160,7 @@ private fun MVPPanel(
         modifier = modifier,
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             game.mostValuablePlayers.forEach { mvp ->
                 MVPCard(

--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailHeader.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailHeader.kt
@@ -49,6 +49,7 @@ private fun TeamScores(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             TeamNameLogo(
                 team = game.homeTeam.team,
@@ -61,6 +62,7 @@ private fun TeamScores(
 
         Row(
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             TeamScore(
                 teamGameResult = game.awayTeam,

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/MostValuablePlayerDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/MostValuablePlayerDisplayModel.kt
@@ -24,14 +24,34 @@ private fun MostValuablePlayer.highlightStats(): List<StatDisplayModel> {
         val savePercentage = saves / shots
 
         listOf(
-            StatDisplayModel("GA", this.stats.goalsAgainst.toString()),
-            StatDisplayModel("SV%", numberFormatter.formatSavePercentage(savePercentage)),
+            StatDisplayModel(
+                shortCode = "GA",
+                fullName = "Goals Against",
+                value = this.stats.goalsAgainst.toString(),
+            ),
+            StatDisplayModel(
+                shortCode = "SV%",
+                fullName = "Save Percentage",
+                value = numberFormatter.formatSavePercentage(savePercentage),
+            ),
         )
     } else {
         listOf(
-            StatDisplayModel("G", stats.goals.toString()),
-            StatDisplayModel("A", stats.assists.toString()),
-            StatDisplayModel("P", stats.points.toString()),
+            StatDisplayModel(
+                shortCode = "G",
+                fullName = "Goals",
+                value = stats.goals.toString(),
+            ),
+            StatDisplayModel(
+                shortCode = "A",
+                fullName = "Assists",
+                value = stats.assists.toString(),
+            ),
+            StatDisplayModel(
+                shortCode = "P",
+                fullName = "Points",
+                value = stats.points.toString(),
+            ),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/StatDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/StatDisplayModel.kt
@@ -1,6 +1,7 @@
 package com.adammcneilly.pwhl.mobile.shared.displaymodels
 
 data class StatDisplayModel(
-    val key: String,
+    val shortCode: String,
+    val fullName: String,
     val value: String,
 )

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
@@ -65,12 +65,16 @@ private fun Stats(
         shape = MaterialTheme.shapes.large,
     ) {
         Row(
-            horizontalArrangement = Arrangement.SpaceEvenly,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
                 .fillMaxWidth(),
         ) {
             mvp.highlightStats.forEach { stat ->
-                StatItem(stat)
+                StatItem(
+                    stat = stat,
+                    modifier = Modifier
+                        .weight(1F),
+                )
             }
         }
     }
@@ -79,9 +83,11 @@ private fun Stats(
 @Composable
 private fun StatItem(
     stat: StatDisplayModel,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
     ) {
         val statText = if (currentWindowSizeClass().widthSizeClass == WindowWidthSizeClass.Expanded) {
             stat.fullName

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
@@ -73,7 +73,11 @@ private fun Stats(
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 8.dp,
+                    vertical = 4.dp,
+                ),
         ) {
             mvp.highlightStats.forEach { stat ->
                 StatItem(

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/mvp/MVPCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +26,7 @@ import com.adammcneilly.pwhl.mobile.shared.displaymodels.ImageDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.MostValuablePlayerDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.StatDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.ui.components.ImageWrapper
+import com.adammcneilly.pwhl.mobile.shared.ui.util.currentWindowSizeClass
 
 @Composable
 fun MVPCard(
@@ -81,8 +83,14 @@ private fun StatItem(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        val statText = if (currentWindowSizeClass().widthSizeClass == WindowWidthSizeClass.Expanded) {
+            stat.fullName
+        } else {
+            stat.shortCode
+        }
+
         Text(
-            text = stat.key,
+            text = statText,
             style = MaterialTheme.typography.titleMedium,
         )
 


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

If we're on a larger screen with available space, we will show "Goals" and "Assists" instead of "G" and "A". 
