### PR TITLE
Converting MVP card to PlayerHighlightCard.

### DIFF
--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
@@ -35,8 +35,8 @@ import androidx.xr.compose.subspace.layout.width
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.GameDetailDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.gamedetail.GameDetailState
 import com.adammcneilly.pwhl.mobile.shared.gamedetail.GameDetailStatsTab
-import com.adammcneilly.pwhl.mobile.shared.gamedetail.mvp.MVPCard
 import com.adammcneilly.pwhl.mobile.shared.gamedetail.playbyplay.PlayByPlayList
+import com.adammcneilly.pwhl.mobile.shared.ui.components.PlayerHighlightCard
 import com.adammcneilly.pwhl.mobile.shared.ui.components.SpatialSurface
 import com.adammcneilly.pwhl.mobile.shared.xr.XRSession
 
@@ -163,7 +163,7 @@ private fun MVPPanel(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             game.mostValuablePlayers.forEach { mvp ->
-                MVPCard(
+                PlayerHighlightCard(
                     mvp = mvp,
                     shape = MaterialTheme.shapes.extraLarge,
                     modifier = Modifier

--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/xr/ImmersiveGameDetailContent.android.kt
@@ -164,7 +164,7 @@ private fun MVPPanel(
         ) {
             game.mostValuablePlayers.forEach { mvp ->
                 PlayerHighlightCard(
-                    mvp = mvp,
+                    playerHighlight = mvp,
                     shape = MaterialTheme.shapes.extraLarge,
                     modifier = Modifier
                         .fillMaxWidth(),

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/data/hockeytech/dto/HockeyTechGamePlayerStatsDTO.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/data/hockeytech/dto/HockeyTechGamePlayerStatsDTO.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pwhl.mobile.shared.data.hockeytech.dto
 
-import com.adammcneilly.pwhl.mobile.shared.models.GamePlayerStats
+import com.adammcneilly.pwhl.mobile.shared.models.Stats
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -35,8 +35,8 @@ data class HockeyTechGamePlayerStatsDTO(
     @SerialName("toi")
     val toi: String? = null,
 ) {
-    fun parseGamePlayerStats(): GamePlayerStats {
-        return GamePlayerStats(
+    fun parseGamePlayerStats(): Stats {
+        return Stats(
             assists = assists ?: 0,
             goals = goals ?: 0,
             points = points ?: 0,

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/data/hockeytech/dto/HockeyTechMVPDTO.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/data/hockeytech/dto/HockeyTechMVPDTO.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pwhl.mobile.shared.data.hockeytech.dto
 
-import com.adammcneilly.pwhl.mobile.shared.models.MostValuablePlayer
+import com.adammcneilly.pwhl.mobile.shared.models.PlayerStats
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,7 +15,7 @@ data class HockeyTechMVPDTO(
     @SerialName("team")
     val team: HockeyTechTeamInfoDTO? = null,
 ) {
-    fun parseMostValuablePlayer(): MostValuablePlayer {
+    fun parseMostValuablePlayer(): PlayerStats {
         require(team != null) {
             "Cannot parse MVP without team."
         }
@@ -28,7 +28,7 @@ data class HockeyTechMVPDTO(
             "Cannot parse MVP without player stats."
         }
 
-        return MostValuablePlayer(
+        return PlayerStats(
             team = team.parseTeam(),
             player = player.info.parsePlayer(),
             stats = player.stats.parseGamePlayerStats(),

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameDetailDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/GameDetailDisplayModel.kt
@@ -14,7 +14,7 @@ data class GameDetailDisplayModel(
     val id: String,
     val homeTeam: TeamGameDetailResultDisplayModel,
     val awayTeam: TeamGameDetailResultDisplayModel,
-    val mostValuablePlayers: List<MostValuablePlayerDisplayModel>,
+    val mostValuablePlayers: List<PlayerHighlightDisplayModel>,
     val status: String,
     val dateString: String,
 ) {
@@ -28,7 +28,7 @@ data class GameDetailDisplayModel(
             teamGameResult = game.awayTeam,
             gameStarted = game.isStarted,
         ),
-        mostValuablePlayers = game.mostValuablePlayers.map(::MostValuablePlayerDisplayModel),
+        mostValuablePlayers = game.mostValuablePlayers.map(::PlayerHighlightDisplayModel),
         status = game.status,
         dateString = game.dateString(),
     )

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/PlayerHighlightDisplayModel.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/displaymodels/PlayerHighlightDisplayModel.kt
@@ -1,21 +1,21 @@
 package com.adammcneilly.pwhl.mobile.shared.displaymodels
 
-import com.adammcneilly.pwhl.mobile.shared.models.MostValuablePlayer
+import com.adammcneilly.pwhl.mobile.shared.models.PlayerStats
 import com.adammcneilly.pwhl.mobile.shared.util.numberFormatter
 
-data class MostValuablePlayerDisplayModel(
+data class PlayerHighlightDisplayModel(
     val team: TeamDisplayModel,
     val player: PlayerDisplayModel,
     val highlightStats: List<StatDisplayModel>,
 ) {
-    constructor(mvp: MostValuablePlayer) : this(
-        team = TeamDisplayModel(mvp.team),
-        player = PlayerDisplayModel(mvp.player),
-        highlightStats = mvp.highlightStats(),
+    constructor(playerStats: PlayerStats) : this(
+        team = TeamDisplayModel(playerStats.team),
+        player = PlayerDisplayModel(playerStats.player),
+        highlightStats = playerStats.highlightStats(),
     )
 }
 
-private fun MostValuablePlayer.highlightStats(): List<StatDisplayModel> {
+private fun PlayerStats.highlightStats(): List<StatDisplayModel> {
     val numberFormatter = numberFormatter()
 
     return if (this.isGoalie) {

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/GameDetailSummaryTab.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/GameDetailSummaryTab.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.GameDetailDisplayModel
-import com.adammcneilly.pwhl.mobile.shared.gamedetail.mvp.MVPCard
+import com.adammcneilly.pwhl.mobile.shared.ui.components.PlayerHighlightCard
 
 @Composable
 fun GameDetailSummaryTab(
@@ -55,7 +55,7 @@ private fun LazyListScope.mvpSection(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 items(game.mostValuablePlayers) { mvp ->
-                    MVPCard(
+                    PlayerHighlightCard(
                         mvp = mvp,
                     )
                 }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/GameDetailSummaryTab.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/gamedetail/GameDetailSummaryTab.kt
@@ -56,7 +56,7 @@ private fun LazyListScope.mvpSection(
             ) {
                 items(game.mostValuablePlayers) { mvp ->
                     PlayerHighlightCard(
-                        mvp = mvp,
+                        playerHighlight = mvp,
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/models/GameDetail.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/models/GameDetail.kt
@@ -6,7 +6,7 @@ data class GameDetail(
     val id: String,
     val homeTeam: TeamGameDetailResult,
     val awayTeam: TeamGameDetailResult,
-    val mostValuablePlayers: List<MostValuablePlayer>,
+    val mostValuablePlayers: List<PlayerStats>,
     val time: Instant,
     val status: String,
     val isStarted: Boolean,

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/models/PlayerStats.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/models/PlayerStats.kt
@@ -1,8 +1,8 @@
 package com.adammcneilly.pwhl.mobile.shared.models
 
-data class MostValuablePlayer(
+data class PlayerStats(
     val team: Team,
     val player: Player,
-    val stats: GamePlayerStats,
+    val stats: Stats,
     val isGoalie: Boolean,
 )

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/models/Stats.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/models/Stats.kt
@@ -1,6 +1,6 @@
 package com.adammcneilly.pwhl.mobile.shared.models
 
-data class GamePlayerStats(
+data class Stats(
     val assists: Int,
     val goals: Int,
     val points: Int,

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/components/PlayerHighlightCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/components/PlayerHighlightCard.kt
@@ -33,7 +33,7 @@ import com.adammcneilly.pwhl.mobile.shared.ui.util.currentWindowSizeClass
 
 @Composable
 fun PlayerHighlightCard(
-    mvp: PlayerHighlightDisplayModel,
+    playerHighlight: PlayerHighlightDisplayModel,
     modifier: Modifier = Modifier,
     shape: Shape = MaterialTheme.shapes.large,
 ) {
@@ -51,19 +51,19 @@ fun PlayerHighlightCard(
                 horizontalArrangement = Arrangement.spacedBy(PWHLTheme.dimensions.componentHorizontalPadding),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                PlayerImage(mvp)
+                PlayerImage(playerHighlight)
 
-                PlayerInfo(mvp)
+                PlayerInfo(playerHighlight)
             }
 
-            Stats(mvp)
+            Stats(playerHighlight)
         }
     }
 }
 
 @Composable
 private fun Stats(
-    mvp: PlayerHighlightDisplayModel,
+    playerHighlight: PlayerHighlightDisplayModel,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.secondaryContainer,
@@ -78,7 +78,7 @@ private fun Stats(
                     vertical = 4.dp,
                 ),
         ) {
-            mvp.highlightStats.forEach { stat ->
+            playerHighlight.highlightStats.forEach { stat ->
                 StatItem(
                     stat = stat,
                     modifier = Modifier
@@ -117,18 +117,18 @@ private fun StatItem(
 
 @Composable
 private fun PlayerInfo(
-    mvp: PlayerHighlightDisplayModel,
+    playerHighlight: PlayerHighlightDisplayModel,
 ) {
     Column {
-        PlayerName(mvp)
+        PlayerName(playerHighlight)
 
-        PlayerSubtitle(mvp)
+        PlayerSubtitle(playerHighlight)
     }
 }
 
 @Composable
 private fun PlayerName(
-    mvp: PlayerHighlightDisplayModel,
+    playerHighlight: PlayerHighlightDisplayModel,
 ) {
     val imageSize = PWHLTheme.dimensions.imageSizeDefault
 
@@ -142,14 +142,14 @@ private fun PlayerName(
     )
 
     Text(
-        text = mvp.player.fullName,
+        text = playerHighlight.player.fullName,
         style = textStyle,
     )
 }
 
 @Composable
 private fun PlayerSubtitle(
-    mvp: PlayerHighlightDisplayModel,
+    playerHighlight: PlayerHighlightDisplayModel,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -169,13 +169,13 @@ private fun PlayerSubtitle(
         )
 
         ImageWrapper(
-            image = mvp.team.image,
-            contentDescription = mvp.team.name,
+            image = playerHighlight.team.image,
+            contentDescription = playerHighlight.team.name,
             modifier = Modifier
                 .size(fontSizeDp),
         )
 
-        val subtitle = "#${mvp.player.jerseyNumber} • ${mvp.player.position}"
+        val subtitle = "#${playerHighlight.player.jerseyNumber} • ${playerHighlight.player.position}"
 
         Text(
             text = subtitle,
@@ -186,11 +186,11 @@ private fun PlayerSubtitle(
 
 @Composable
 private fun PlayerImage(
-    mvp: PlayerHighlightDisplayModel,
+    playerHighlight: PlayerHighlightDisplayModel,
 ) {
     ImageWrapper(
-        image = mvp.player.playerImage ?: ImageDisplayModel.Placeholder,
-        contentDescription = mvp.player.fullName,
+        image = playerHighlight.player.playerImage ?: ImageDisplayModel.Placeholder,
+        contentDescription = playerHighlight.player.fullName,
         contentScale = ContentScale.Crop,
         modifier = Modifier
             .size(PWHLTheme.dimensions.imageSizeDefault)

--- a/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/components/PlayerHighlightCard.kt
+++ b/shared/src/commonMain/kotlin/com/adammcneilly/pwhl/mobile/shared/ui/components/PlayerHighlightCard.kt
@@ -1,6 +1,6 @@
 @file:Suppress("MagicNumber")
 
-package com.adammcneilly.pwhl.mobile.shared.gamedetail.mvp
+package com.adammcneilly.pwhl.mobile.shared.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -26,15 +26,14 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.ImageDisplayModel
-import com.adammcneilly.pwhl.mobile.shared.displaymodels.MostValuablePlayerDisplayModel
+import com.adammcneilly.pwhl.mobile.shared.displaymodels.PlayerHighlightDisplayModel
 import com.adammcneilly.pwhl.mobile.shared.displaymodels.StatDisplayModel
-import com.adammcneilly.pwhl.mobile.shared.ui.components.ImageWrapper
 import com.adammcneilly.pwhl.mobile.shared.ui.theme.PWHLTheme
 import com.adammcneilly.pwhl.mobile.shared.ui.util.currentWindowSizeClass
 
 @Composable
-fun MVPCard(
-    mvp: MostValuablePlayerDisplayModel,
+fun PlayerHighlightCard(
+    mvp: PlayerHighlightDisplayModel,
     modifier: Modifier = Modifier,
     shape: Shape = MaterialTheme.shapes.large,
 ) {
@@ -64,7 +63,7 @@ fun MVPCard(
 
 @Composable
 private fun Stats(
-    mvp: MostValuablePlayerDisplayModel,
+    mvp: PlayerHighlightDisplayModel,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.secondaryContainer,
@@ -118,7 +117,7 @@ private fun StatItem(
 
 @Composable
 private fun PlayerInfo(
-    mvp: MostValuablePlayerDisplayModel,
+    mvp: PlayerHighlightDisplayModel,
 ) {
     Column {
         PlayerName(mvp)
@@ -129,7 +128,7 @@ private fun PlayerInfo(
 
 @Composable
 private fun PlayerName(
-    mvp: MostValuablePlayerDisplayModel,
+    mvp: PlayerHighlightDisplayModel,
 ) {
     val imageSize = PWHLTheme.dimensions.imageSizeDefault
 
@@ -150,7 +149,7 @@ private fun PlayerName(
 
 @Composable
 private fun PlayerSubtitle(
-    mvp: MostValuablePlayerDisplayModel,
+    mvp: PlayerHighlightDisplayModel,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -187,7 +186,7 @@ private fun PlayerSubtitle(
 
 @Composable
 private fun PlayerImage(
-    mvp: MostValuablePlayerDisplayModel,
+    mvp: PlayerHighlightDisplayModel,
 ) {
     ImageWrapper(
         image = mvp.player.playerImage ?: ImageDisplayModel.Placeholder,


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

This makes it reusable so we can highlight other players like top scorers for a team. 
