### PR TITLE
XR check fix.

### DIFF
--- a/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/xr/XRSession.android.kt
+++ b/shared/src/androidMain/kotlin/com/adammcneilly/pwhl/mobile/shared/xr/XRSession.android.kt
@@ -1,12 +1,17 @@
 package com.adammcneilly.pwhl.mobile.shared.xr
 
 import androidx.compose.runtime.Composable
+import androidx.xr.compose.platform.LocalSession
 import androidx.xr.compose.platform.LocalSpatialCapabilities
 import androidx.xr.compose.platform.LocalSpatialConfiguration
 import androidx.xr.compose.platform.SpatialConfiguration
 
 @Composable
 actual fun currentXRSession(): XRSession? {
+    if (LocalSession.current == null) {
+        return null
+    }
+
     return LocalSpatialConfiguration.current.let(::AndroidXRSession)
 }
 


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->

Checking for a local session before returning a session instance, so the XR button is only available in XR situations. 
